### PR TITLE
Add system statistics, file retrieval, and category count functions

### DIFF
--- a/contracts/medical-records.clar
+++ b/contracts/medical-records.clar
@@ -241,3 +241,77 @@
   )
 )
 
+;; Gets system statistics
+(define-public (get-system-stats)
+  (ok (var-get records-count))
+)
+
+;; Retrieves subject identifier from file
+(define-public (get-subject-id (file-id uint))
+  (let
+    (
+      (file-info (unwrap! (map-get? health-files { file-id: file-id }) NOT_FOUND_ERROR))
+    )
+    (ok (get subject-identifier file-info))
+  )
+)
+
+;; Retrieves provider information for file
+(define-public (get-file-provider (file-id uint))
+  (let
+    (
+      (file-info (unwrap! (map-get? health-files { file-id: file-id }) NOT_FOUND_ERROR))
+    )
+    (ok (get provider-principal file-info))
+  )
+)
+
+;; Retrieves file creation timestamp
+(define-public (get-file-timestamp (file-id uint))
+  (let
+    (
+      (file-info (unwrap! (map-get? health-files { file-id: file-id }) NOT_FOUND_ERROR))
+    )
+    (ok (get timestamp-block file-info))
+  )
+)
+
+;; Retrieves file size information
+(define-public (get-file-size (file-id uint))
+  (let
+    (
+      (file-info (unwrap! (map-get? health-files { file-id: file-id }) NOT_FOUND_ERROR))
+    )
+    (ok (get content-volume file-info))
+  )
+)
+
+;; Retrieves file clinical summary
+(define-public (get-file-summary (file-id uint))
+  (let
+    (
+      (file-info (unwrap! (map-get? health-files { file-id: file-id }) NOT_FOUND_ERROR))
+    )
+    (ok (get clinical-summary file-info))
+  )
+)
+
+;; Retrieves all categories for a file
+(define-public (get-file-categories (file-id uint))
+  (let
+    (
+      (file-info (unwrap! (map-get? health-files { file-id: file-id }) NOT_FOUND_ERROR))
+    )
+    (ok (get categories file-info))
+  )
+)
+
+;; Counts the number of categories for a file
+(define-public (count-file-categories (file-id uint))
+  (let
+    (
+      (file-info (unwrap! (map-get? health-files { file-id: file-id }) NOT_FOUND_ERROR))
+    )
+    (ok (len (get categories file-info)))
+  )
+)


### PR DESCRIPTION
## Implement System Statistics and File Metadata Retrieval  

### Summary  
This update enhances the **Medical Database Management System** by introducing retrieval functions for file metadata, system statistics, and category counts.  

### Key Features  
- **System Statistics (`get-system-stats`)**  
  - Retrieves the total count of medical records in the system.  

- **File Metadata Retrieval**  
  - `get-subject-id`: Fetches the subject identifier of a file.  
  - `get-file-provider`: Retrieves the provider responsible for a file.  
  - `get-file-timestamp`: Gets the creation timestamp of a file.  
  - `get-file-size`: Returns the size of a file in bytes.  
  - `get-file-summary`: Fetches the clinical summary of a file.  
  - `get-file-categories`: Retrieves the list of categories assigned to a file.  
  - `count-file-categories`: Counts the number of categories associated with a file.  

### Impact  
- Improves **data retrieval efficiency** for users and administrators.  
- Enhances **visibility into system statistics**.  
- Supports **structured metadata access** for external integrations.  

### Next Steps  
- Implement paginated file listing for large datasets.  
- Introduce search and filtering capabilities for medical records.  
